### PR TITLE
Add schedule and featured speakers

### DIFF
--- a/content/speakers/alastair-turner.md
+++ b/content/speakers/alastair-turner.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Open Source Database Enthusiast
 image: images/speakers/alastair-turner.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -17,10 +16,8 @@ social:
 talks:
   - title: "Valkey 101: Keep Calm, and Fork On"
     link: talks/valkey-101-keep-calm-and-fork-on/
-    current: true
   - title: "False Positives, Real Gains: Valkey's Probabilistic Filters"
     link: talks/false-positives-real-gains-valkeys-probabilistic-filters/
-    current: true
 ---
 
 Since 1995, Alastair has administered, programmed and supported all things database, from Access to Universe, settling on Postgres around 2002. He recently left the dark side of vendor presales and currently works in community advocacy at Percona.

--- a/content/speakers/aleksey-tsalolikhin.md
+++ b/content/speakers/aleksey-tsalolikhin.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Site Reliability Engineer
 image: images/speakers/aleksey-tsalolikhin.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: "Power Editing with Vi: Basics"
     link: talks/power-editing-with-vi-basics/
-    current: true
 ---
 
 Aleksey Tsalolikhin started his IT career in tech support at EarthLink (ISP) in

--- a/content/speakers/alex-juarez.md
+++ b/content/speakers/alex-juarez.md
@@ -4,8 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Software Maintenance Engineer
 image: images/speakers/alex-juarez.jpg
-current: true
-featured: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -20,7 +18,6 @@ talks:
     link: "talks/things-i-wish-i-knew-about-containers-sooner-rather-than-later/"
   - title: "Keep it Local: Intro to learning Kubernetes using minikube"
     link: talks/keep-it-local-intro-to-learning-kubernetes-using-minikube/
-    current: true
 ---
 
 Alex is an open-source enthusiast with over 25 years of experience in Linux,

--- a/content/speakers/anupama-pathirage.md
+++ b/content/speakers/anupama-pathirage.md
@@ -4,7 +4,6 @@ description: "Texas Linux Fest 2026"
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Head of Engineering"
 image: "images/speakers/anupama-pathirage.jpg"
-current: true
 
 social:
   - icon: "fa-solid fa-blog"
@@ -20,8 +19,6 @@ social:
 talks:
   - title: "Effortless Cloud Integrations: Ballerina for Kubernetes and Beyond"
     link: "talks/effortless-cloud-integrations-ballerina-for-kubernetes-and-beyond/"
-    current: true
-
 ---
 
 Anupama, Head of Engineering - Integration at WSO2, leads the development of the

--- a/content/speakers/bramhanand-lingala.md
+++ b/content/speakers/bramhanand-lingala.md
@@ -4,7 +4,6 @@ description: "Texas Linux Fest 2026"
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Data Engineer & SRE"
 image: "images/speakers/bramhanand-lingala.jpg"
-current: true
 
 social:
   - icon: "fa-brands fa-linkedin"
@@ -13,8 +12,6 @@ social:
 talks:
   - title: "Adopting NoSQL at Scale: Strategic Models, Performance Trade-Offs, and Integration Pitfalls"
     link: "talks/adopting-nosql-at-scale-strategic-models-performance-trade-offs-and-integration-pitfalls/"
-    current: true
-
 ---
 Bramhanand Lingala is a seasoned Senior Data Engineer and certified Google 
 Associate Cloud Engineer with over 20 years of experience in data infrastructure

--- a/content/speakers/brett-estrade.md
+++ b/content/speakers/brett-estrade.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Chairman, Science Perl Committee; Co-Editor Science Perl Journal
 image: images/speakers/brett-estrade.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -17,7 +16,6 @@ social:
 talks:
   - title: Real-Time Hurricane Storm Surge Prediction using Open Source
     link: talks/real-time-hurricane-storm-surge-prediction-using-open-source/
-    current: true
 ---
 
 **Brett Estrade** is a Houston-based software developer and open-source

--- a/content/speakers/caleb-schoepp.md
+++ b/content/speakers/caleb-schoepp.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Software Engineer"
 image: "images/speakers/caleb-schoepp.jpg"
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -21,7 +20,6 @@ talks:
     link: "talks/what-actually-is-webassembly/"
   - title: "Truly Portable Code: Serverless WebAssembly in a Distributed World"
     link: talks/truly-portable-code-serverless-webassembly-in-a-distributed-world/
-    current: true
 ---
 
 Caleb Schoepp is a software engineer at Fermyon. Before working at Fermyon he

--- a/content/speakers/carl-perry.md
+++ b/content/speakers/carl-perry.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Software Engineer
 image: images/speakers/carl-perry.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: "Linux on RISC-V: Where we are, where we're going, and how you can jump in"
     link: talks/linux-on-risc-v-where-we-are-where-were-going-and-how-you-can-jump-in/
-    current: true
 ---
 
 Carl is a RISC-V Ambassador, organizer of the Austin RISC-V Group, but that's

--- a/content/speakers/carl-thompson.md
+++ b/content/speakers/carl-thompson.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Linux Systems Architect
 image: images/speakers/carl-thompson.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -15,7 +14,6 @@ social:
 talks:
   - title: Demystifying SELinux
     link: talks/demystifying-selinux/
-    current: true
 ---
 
 I am Carl "Redragon" Thompson.

--- a/content/speakers/chris-arges.md
+++ b/content/speakers/chris-arges.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior System Software Engineer
 image: images/speakers/chris-arges.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: Verified Debian Packaging at Scale
     link: talks/verified-debian-packaging-at-scale/
-    current: true
 ---
 
 I'm a Senior System Software Engineer at Cloudflare, with extensive experience

--- a/content/speakers/christopher-hobbs.md
+++ b/content/speakers/christopher-hobbs.md
@@ -1,0 +1,20 @@
+---
+title: Christopher Hobbs
+description: Texas Linux Fest
+page_header_bg: images/background/page-title-bg.jpg
+designation: Infrastructure Engineer
+link: https://pretalx.com/txlf2026/speaker/BTDC83/
+image: https://pretalx.com/media/avatars/WHQPZJ_fh2W9Ei.webp
+featured: true
+
+social:
+  - icon: fa-brands fa-linkedin
+    link: https://www.linkedin.com/in/cmhobbs/
+  - icon: fa-brands fa-github
+    link: https://github.com/cmhobbs
+---
+
+One half hillbilly and one half (cyber)punk, Hobbs is a Mercenary Janitor that
+hails from the foothills of the Ozark "mountains."  He has been daily driving
+Linux since the mid-90s.  He works as a freelance engineer supervised by three
+cats.

--- a/content/speakers/cody-lee-cochran.md
+++ b/content/speakers/cody-lee-cochran.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Principal Engineer and Enterprise Architect"
 image: "images/speakers/cody-lee-cochran.jpg"
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -19,7 +18,6 @@ talks:
     link: "talks/bash-programming/"
   - title: "Pipelines as a Service: Codifying Workflows & Other Tribal Knowledge"
     link: talks/pipelines-as-a-service-codifying-workflows-other-tribal-knowledge/
-    current: true
 ---
 
 Cody Lee Cochran is a Principal Engineer and Enterprise Architect for a small,

--- a/content/speakers/darin-pope.md
+++ b/content/speakers/darin-pope.md
@@ -4,7 +4,6 @@ description: "Texas Linux Fest 2026"
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Developer Advocate"
 image: "images/speakers/darin-pope.jpg"
-current: false
 
 social:
   - icon: "fa-solid fa-globe"
@@ -18,7 +17,6 @@ social:
 talks:
   - title: "Best Practices for Managing Jenkins"
     link: "talks/best-practices-for-managing-jenkins/"
-    current: false
 
 ---
 

--- a/content/speakers/dave-mcallister.md
+++ b/content/speakers/dave-mcallister.md
@@ -4,7 +4,6 @@ description: "Texas Linux Fest 2026"
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Open Source Technologist"
 image: "images/speakers/dave-mcallister.jpg"
-current: true
 
 social:
   - icon: "fa-solid fa-globe"
@@ -18,8 +17,6 @@ social:
 talks:
   - title: "Exploring Kubernetes Gateway API and NGINX Gateway Fabric"
     link: "talks/exploring-kubernetes-gateway-api-and-nginx-gateway-fabric/"
-    current: true
-
 ---
 
 Currently providing technical evangelism for NGINX, Dave works with DevOps, 

--- a/content/speakers/david-duncan.md
+++ b/content/speakers/david-duncan.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: Principal Partner Solutions Architect
 image: "images/speakers/david-duncan.jpg"
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -21,7 +20,6 @@ talks:
     link: "talks/building-a-fedora-kde-image-for-use-with-public-cloud-providers/"
   - title: "The Great Texas Agent-Off: RamaLama, Podman, and DIY AI Bots!"
     link: talks/the-great-texas-agent-off-ramalama-podman-and-diy-ai-bots/
-    current: true
 ---
 
 David Duncan is an AWS Partner Solution Architect who is keenly focused on open

--- a/content/speakers/dustin-kirkland.md
+++ b/content/speakers/dustin-kirkland.md
@@ -4,8 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Vice President
 image: images/speakers/dustin-kirkland.jpg
-current: true
-featured: true
 
 social:
   - icon: fa-solid fa-globe

--- a/content/speakers/eduardo-robles.md
+++ b/content/speakers/eduardo-robles.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest 2026
 page_header_bg: images/background/page-title-bg.jpg
 designation: "Cybersecurity Analyst"
 image: images/speakers/eduardo-robles.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: "I got Malware, BTW. A quick look at the rising trend of Linux Malware."
     link: "talks/i-got-malware-btw/"
-    current: true
 ---
 
 Eduardo Robles works for County of Hidalgo IT department as a Cybersecurity 

--- a/content/speakers/eric-hendricks.md
+++ b/content/speakers/eric-hendricks.md
@@ -1,0 +1,21 @@
+---
+title: Eric Hendricks
+description: Texas Linux Fest
+page_header_bg: images/background/page-title-bg.jpg
+designation: Technical Product Marketing Manager
+link: https://pretalx.com/txlf2026/speaker/ZX7U8V/
+image: https://pretalx.com/media/avatars/LXEXJE_G2ALXhv.webp
+featured: true
+
+social:
+  - icon: fa-brands fa-linkedin
+    link: https://www.linkedin.com/in/itguyeric/
+  - icon: fa-brands fa-github
+    link: https://github.com/itguyeric
+---
+
+Eric "The IT Guy" Hendricks is a former Linux Systems Administrator turned
+Product Marketing Manager and an instructor at Johnson County Community
+College.  He's spent over 15 years in IT building, breaking, and teaching Linux
+systems.  Eric now focuses on helping others navigate tech careers with
+honesty, humor, and a deep love for open source and community.

--- a/content/speakers/faizal-khader.md
+++ b/content/speakers/faizal-khader.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Staff Solutions Architect
 image: images/speakers/faizal-khader.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -15,7 +14,6 @@ social:
 talks:
   - title: Explore Deploying and Managing Large Language Models with Red Hat Enterprise Linux 10 and Red Hat AI Serving
     link: talks/explore-deploying-and-managing-large-language-models-with-red-hat-enterprise-linux-10-and-red-hat-ai-serving/
-    current: true
 ---
 
 Faizal Khader, Associate Principal Solution Architect at Red Hat, brings

--- a/content/speakers/fred-lawler.md
+++ b/content/speakers/fred-lawler.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Systems Engineer"
 image: "images/speakers/fred-lawler.jpg"
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -17,10 +16,8 @@ talks:
     link: "talks/connect-why-you-so-slow/"
   - title: Containers without Docker
     link: talks/containers-without-docker/
-    current: true
   - title: Verified Debian Packaging at Scale
     link: talks/verified-debian-packaging-at-scale/
-    current: true
 ---
 
 Fred is a Systems Engineer on Cloudflare's Linux team primarily maintaining and

--- a/content/speakers/hoang-dinh-nguyen.md
+++ b/content/speakers/hoang-dinh-nguyen.md
@@ -4,7 +4,6 @@ description: "Texas Linux Fest 2026"
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Platform Engineer"
 image: "images/speakers/hoang-dinh-nguyen.jpg"
-current: true
 
 social:
   - icon: "fa-solid fa-globe"
@@ -17,8 +16,6 @@ social:
 talks:
   - title: "Kusion and Internal Developer Platform: Optimize the Software Development Process"
     link: "talks/kusion-and-internal-developer-platform-optimize-the-software-develement-process/"
-    current: true
-
 ---
 Maintainer of KusionStack - first-ever open-source project which included in 
 both the CNCF Sandbox and the Platform Tooling Landscape that focuses on the 

--- a/content/speakers/ignat-korchagin.md
+++ b/content/speakers/ignat-korchagin.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Engineering Manager
 image: images/speakers/ignat-korchagin.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: An engineer's guide to Linux Kernel upgrades
     link: talks/an-engineers-guide-to-linux-kernel-upgrades/
-    current: true
 ---
 
 Ignat is a systems engineer at Cloudflare working mostly on Linux, platforms

--- a/content/speakers/james-denton.md
+++ b/content/speakers/james-denton.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Principal Architect
 image: images/speakers/james-denton.png
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -17,7 +16,6 @@ social:
 talks:
   - title: "From Open Source to Open Talk: Meet the Experts"
     link: talks/from-open-source-to-open-talk-meet-the-experts/
-    current: true
 ---
 
 I've been in the Information Technology field for over 15 years, cutting my

--- a/content/speakers/jj-asghar.md
+++ b/content/speakers/jj-asghar.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Developer Advocate
 image: images/speakers/jj-asghar.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: Using Open Source AI and Linux to help Medical School Students
     link: talks/using-open-source-ai-and-linux-to-help-medical-school-students/
-    current: true
 ---
 
 JJ works as a Developer Advocate representing the IBM Cloud all over the world.

--- a/content/speakers/jon-roberts.md
+++ b/content/speakers/jon-roberts.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Development Manager
 image: images/speakers/jon-roberts.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -17,7 +16,6 @@ social:
 talks:
   - title: "WSL: Meet the bastard I adopted and learn to play with them."
     link: talks/wsl-meet-the-bastard-i-adopted-and-learn-to-play-with-them/
-    current: true
 ---
 
 Jon has over 25 years of experience in software development working in

--- a/content/speakers/josh-villarreal.md
+++ b/content/speakers/josh-villarreal.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: General Manager and Senior Director
 image: images/speakers/josh-villarreal.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -13,7 +12,6 @@ social:
 talks:
   - title: "From Open Source to Open Talk: Meet the Experts"
     link: talks/from-open-source-to-open-talk-meet-the-experts/
-    current: true
 ---
 
 Josh Villarreal is a 14 year Racker who has been working in the OpenStack arena

--- a/content/speakers/joshua-lee.md
+++ b/content/speakers/joshua-lee.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Open Source Developer Advocate
 image: images/speakers/joshua-lee.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: "Magical Mystery Tour: A Roundup of Observability Datastores"
     link: talks/magical-mystery-tour-a-roundup-of-observability-datastores/
-    current: true
 ---
 
 Joshua is a seasoned software developer with over a decade of experience,

--- a/content/speakers/ken-crandall.md
+++ b/content/speakers/ken-crandall.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Strategic Product Manager
 image: images/speakers/ken-crandall.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,10 +18,8 @@ social:
 talks:
   - title: "Build Your Own Cloud: Batteries Included!"
     link: talks/build-your-own-cloud-batteries-included/
-    current: true
   - title: "From Open Source to Open Talk: Meet the Experts"
     link: talks/from-open-source-to-open-talk-meet-the-experts/
-    current: true
 ---
 
 Ken Crandall runs Strategic Product Management for OpenStack and Kubernetes at

--- a/content/speakers/kevin-carter.md
+++ b/content/speakers/kevin-carter.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Product Director
 image: images/speakers/kevin-carter.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: "From Open Source to Open Talk: Meet the Experts"
     link: talks/from-open-source-to-open-talk-meet-the-experts/
-    current: true
 ---
 
 I am a technologist on a mission to simplify and automate.  I'm a passionate

--- a/content/speakers/kevin-purdy.md
+++ b/content/speakers/kevin-purdy.md
@@ -1,0 +1,20 @@
+---
+title: Kevin Purdy
+description: Texas Linux Fest
+page_header_bg: images/background/page-title-bg.jpg
+designation: Technical Content Manager
+link: https://pretalx.com/txlf2026/speaker/XQUSBZ/
+image: https://pretalx.com/media/avatars/3PQDZT_rqvBkhh.webp
+featured: true
+
+social:
+  - icon: fa-brands fa-linkedin
+    link: https://www.linkedin.com/in/kevin-purdy-b82176185/
+  - icon: fa-brands fa-github
+    link: https://github.com/kevinpurdy
+---
+
+Kevin Purdy is the Technical Content Manager (read: blogger-in-chief) at
+Tailscale.  He has previously written for Ars Technica, Wirecutter, iFixit,
+Lifehacker, and other publications.  He lives in Washington, D.C. with his
+wife, his dog, and a collection of CPUs and bikes.

--- a/content/speakers/kl-grady.md
+++ b/content/speakers/kl-grady.md
@@ -1,0 +1,21 @@
+---
+title: KL Grady
+description: Texas Linux Fest
+page_header_bg: images/background/page-title-bg.jpg
+designation: Software Engineer
+link: https://pretalx.com/txlf2026/speaker/QW9RNC/
+image: https://pretalx.com/media/avatars/V739RX_cgVFSxV.webp
+featured: true
+
+social:
+  - icon: fa-brands fa-linkedin
+    link: https://www.linkedin.com/in/kerri-leighgrady/
+  - icon: fa-brands fa-github
+    link: https://github.com/klgrady
+---
+
+KL has spent the better part of two decades as a software engineer and
+solutions architect with strong opinions, like maybe you shouldn't run critical
+infrastructure on a language that was thrown together in 10 days and
+immediately became the go-to for GeoCities page designers dead set on fairy
+dust mouse trails.

--- a/content/speakers/kory-heard.md
+++ b/content/speakers/kory-heard.md
@@ -4,7 +4,6 @@ description: "Texas Linux Fest 2026"
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "UNIX Software Engineer"
 image: "images/speakers/kory-heard.jpg"
-current: true
 
 social:
   - icon: "fa-brands fa-linkedin"
@@ -16,7 +15,6 @@ social:
 talks:
   - title: "The Design & Implementation of the Darwin Operating System"
     link: "talks/the-design-and-implementation-of-the-darwin-operating-system/"
-    current: true
 
 ---
 

--- a/content/speakers/major-hayden.md
+++ b/content/speakers/major-hayden.md
@@ -4,8 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Principal Software Engineer
 image: images/speakers/major-hayden.png
-current: true
-featured: true
 
 social:
   - icon: fa-solid fa-globe
@@ -24,7 +22,6 @@ talks:
     link: talks/automated-container-updates-with-github-coreos/
   - title: Don't tell me RAG is easy
     link: talks/dont-tell-me-rag-is-easy/
-    current: true
 ---
 
 Major works on all kinds of technology at Red Hat, including artificial

--- a/content/speakers/mario-limonciello.md
+++ b/content/speakers/mario-limonciello.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Principal Member of Technical Staff
 image: images/speakers/mario-limonciello.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -17,7 +16,6 @@ social:
 talks:
   - title: SteamOS™ on the Lenovo™ Go S
     link: talks/steamos-on-the-lenovo-go-s/
-    current: true
 ---
 
 For my day job I work at AMD for the Client Linux team.  Besides my day job I

--- a/content/speakers/matt-moen.md
+++ b/content/speakers/matt-moen.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: President, Austin ISSA
 image: images/speakers/matt-moen.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -15,7 +14,6 @@ social:
 talks:
   - title: Encrypting Your Infrastructure Without Getting Fired
     link: talks/encrypting-your-infrastructure-without-getting-fired/
-    current: true
 ---
 
 Matt has been involved with all things Security, Open Source and Linux since

--- a/content/speakers/matthew-boehm.md
+++ b/content/speakers/matthew-boehm.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Principal Architect"
 image: "images/speakers/matthew-boehm.jpg"
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,10 +18,8 @@ talks:
     link: "talks/migrating-mysql-to-kubernetes/"
   - title: "Valkey 101: Keep Calm, and Fork On"
     link: talks/valkey-101-keep-calm-and-fork-on/
-    current: true
   - title: "False Positives, Real Gains: Valkey's Probabilistic Filters"
     link: talks/false-positives-real-gains-valkeys-probabilistic-filters/
-    current: true
 ---
 
 My name is Matthew (not Matt).  I've been with Percona for 16 years, and have

--- a/content/speakers/matthew-penaroza.md
+++ b/content/speakers/matthew-penaroza.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Principal Solutions Engineer
 image: images/speakers/matthew-penaroza.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -13,7 +12,6 @@ social:
 talks:
   - title: Mastering Database Selection for System Design
     link: talks/mastering-database-selection-for-system-design/
-    current: true
 ---
 
 I'm a Principal Solutions Engineer at TiDB, where I help enterprises design

--- a/content/speakers/mayur-bhandari.md
+++ b/content/speakers/mayur-bhandari.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Software Engineer
 image: images/speakers/mayur-bhandari.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -13,7 +12,6 @@ social:
 talks:
   - title: "Building Smart Cities with Open Source: How Linux-Based Distributed Systems Are Transforming Urban Infrastructure"
     link: talks/building-smart-cities-with-open-source/
-    current: true
 ---
 
 Mayur Bhandari is a Software Engineer 2 at Microsoft with over 9 years of

--- a/content/speakers/michael-troutman.md
+++ b/content/speakers/michael-troutman.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Documentation Specialist
 image: images/speakers/michael-troutman.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: Lifting the Documentation Burden with Open Source Tools and Resources
     link: talks/lifting-the-documentation-burden-with-open-source-tools-and-resources/
-    current: true
 ---
 
 Michael Troutman works as a documentation specialist at LINBIT, an HA, SDS, and

--- a/content/speakers/mike-schwartz.md
+++ b/content/speakers/mike-schwartz.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest 2026
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: Gluu Founder
 image: "images/speakers/mike-schwartz.jpg"
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -15,7 +14,6 @@ social:
 talks:
   - title: "Security That Scales: How Cedar is Rewriting the Rules of Access"
     link: "talks/security-that-scales-how-cedar-is-rewriting-the-rules-of-access/"
-    current: true
 ---
 
 Mike is the Founder/CEO of Gluu, and leads the Linux Foundation Janssen Project.

--- a/content/speakers/raul-leite.md
+++ b/content/speakers/raul-leite.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Principal Solution Architect
 image: images/speakers/raul-leite.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -17,7 +16,6 @@ social:
 talks:
   - title: Building AI Workloads locally with Podman 
     link: talks/building-ai-workloads-locally-with-podman/
-    current: true
 ---
 
 At Red Hat, Raul Leite serves as a Principal Solution Architect.  Raul is a

--- a/content/speakers/robert-callicotte.md
+++ b/content/speakers/robert-callicotte.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: Devops Supervisor
 image: "images/speakers/robert-callicotte.jpg"
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -17,7 +16,6 @@ social:
 talks:
   - title: "Running CentOS Stream in Production"
     link: "talks/running-centos-stream-in-production/"
-    current: true
 ---
 
 Open source advocate. Fedora package maintainer, EPEL package maintainer, and

--- a/content/speakers/ryan-edge.md
+++ b/content/speakers/ryan-edge.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Software Engineeer
 image: images/speakers/ryan-edge.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -19,7 +18,6 @@ social:
 talks:
   - title: "Accelerating Linux Application Development with Flutter: A Hands-on Workshop"
     link: talks/accelerating-linux-application-development-with-flutter-a-hands-on-workshop/
-    current: true
 ---
 
 Ryan Edge is a software engineer and Flutter GDE living in Charlotte, North

--- a/content/speakers/sai-durga-rithvik-oruganti.md
+++ b/content/speakers/sai-durga-rithvik-oruganti.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Compute Engineer
 image: images/speakers/sai-durga-rithvik-oruganti.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -15,7 +14,6 @@ social:
 talks:
   - title: "Lessons They Don't Teach You in School: A Year in High-Performance Computing"
     link: talks/lessons-they-dont-teach-you-in-school-a-year-in-high-performance-computing/
-    current: true
 ---
 
 Sai is a Compute Engineer at G-Research specializing in Linux and distributed

--- a/content/speakers/sean-thrailkill.md
+++ b/content/speakers/sean-thrailkill.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Software Engineer
 image: images/speakers/sean-thrailkill.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: Create Your Own Bootable Container!
     link: talks/create-your-own-bootable-container/
-    current: true
 ---
 
 Sean is a Software Engineer with 15 years of experience who has a passion for

--- a/content/speakers/sophia-solomon.md
+++ b/content/speakers/sophia-solomon.md
@@ -4,8 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Developer Advocate
 image: images/speakers/sophia-solomon.jpg
-current: true
-featured: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -14,7 +12,6 @@ social:
 talks:
   - title: "Grep Can't Help You Now: Observability for LLMs"
     link: talks/grep-cant-help-you-now-observability-for-llms/
-    current: true
 ---
 
 Hello, my name is Sophia!  With a background in Biochemistry from UT Austin, I

--- a/content/speakers/steve-anness.md
+++ b/content/speakers/steve-anness.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Customer Success Architect
 image: images/speakers/steve-anness.png
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -15,7 +14,6 @@ social:
 talks:
   - title: Auto-instrument all the things with Beyla
     link: talks/auto-instrument-all-the-things-with-beyla/
-    current: true
 ---
 
 Steve Anness is a Senior Customer Success Architect @ Grafana Labs, where he

--- a/content/speakers/sudheer-obbu.md
+++ b/content/speakers/sudheer-obbu.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Vice President, Senior Lead Software Engineer
 image: images/speakers/sudheer-obbu.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -13,7 +12,6 @@ social:
 talks:
   - title: "Securing AI Workloads with Zero Trust: Building Resilient Cloud-Native Systems on Linux"
     link: talks/securing-ai-workloads-with-zero-trust-building-resilient-cloud-native-systems-on-linux/
-    current: true
 ---
 
 Sudheer Obbu is a seasoned DevSecOps, Cloud, and Platform Engineering Services

--- a/content/speakers/swetha-garaga.md
+++ b/content/speakers/swetha-garaga.md
@@ -4,7 +4,6 @@ description: "Texas Linux Fest 2026"
 page_header_bg: "images/background/page-title-bg.jpg"
 designation: "Senior Software Engineer"
 image: "images/speakers/swetha-garaga.jpg"
-current: true
 
 social:
   - icon: "fa-brands fa-linkedin"
@@ -13,7 +12,6 @@ social:
 talks:
   - title: "Human‑Centered Automation: Equity and Efficiency in Modern Warehousing"
     link: "talks/human-centered-automation-equity-and-efficiency-in-modern-warehousing/"
-    current: true
 
 ---
 Swetha Garaga is a highly experienced Senior Software Engineer with a strong 

--- a/content/speakers/thomas-cameron.md
+++ b/content/speakers/thomas-cameron.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Principal Solution Architect
 image: images/speakers/thomas-cameron.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -23,7 +22,6 @@ talks:
     link: talks/learning-okd-on-premise/
   - title: Getting Started with Ansible on Linux
     link: talks/getting-started-with-ansible-on-linux/
-    current: true
 ---
 
 Thomas Cameron has been in IT since 1993.  He started out with Novell NetWare,

--- a/content/speakers/wes-payne.md
+++ b/content/speakers/wes-payne.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Senior Software Development Engineer
 image: images/speakers/wes-payne.jpg
-current: true
 
 social:
   - icon: fa-brands fa-linkedin
@@ -17,7 +16,6 @@ social:
 talks:
   - title: Mesh Network Sidecars for NixOS Services
     link: talks/mesh-network-sidecars-for-nixos-services/
-    current: true
 ---
 
 Wes is a Seattle-based software engineer focused on open source, functional

--- a/content/speakers/willard-nilges.md
+++ b/content/speakers/willard-nilges.md
@@ -4,7 +4,6 @@ description: Texas Linux Fest
 page_header_bg: images/background/page-title-bg.jpg
 designation: Software Engineer
 image: images/speakers/willard-nilges.jpg
-current: true
 
 social:
   - icon: fa-solid fa-globe
@@ -19,7 +18,6 @@ social:
 talks:
   - title: Lessons Learned Building Observability for a Non-Profit
     link: talks/lessons-learned-building-observability-for-a-non-profit/
-    current: true
 ---
 
 Willard is a distributed systems hacker by day, network administrator by night.

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -44,7 +44,7 @@ about:
 ################# Speaker ###################
 speakers:
   enable: true
-  cfp_open: true
+  cfp_open: false
   cfp_link: https://pretalx.com/txlf2026/cfp
   cfp_label: "Submit a talk to our _Call For Papers_"
   title : "Who is _Speaking?_"
@@ -62,14 +62,14 @@ speakers:
   - Gaming
   - Development
   content_cfp: "We invite you to be a part of this exceptional event by sharing your expertise and passion with the community. We are seeking engaging and insightful presentations that cover a broad range of topics related to Linux, open-source software, and the wider technology ecosystem. Whether you have hands-on experience, a new research breakthrough, or an inspiring vision for the future of Linux, we want to hear from you!"
-  more_button_text: "Other speakers"
-  more_button_link: "speakers/"
+  more_button_text: "Schedule"
+  more_button_link: https://pretalx.com/txlf2026/schedule/
 
   # speaker items are coming from "content/speakers" folder
 
 ###################### Tab ####################
 tab:
-  enable : true
+  enable : false
   title : "Event _Schedule_"
   content : "The schedule of events is subject to change without prior notifications."
   tablist:
@@ -235,7 +235,7 @@ registration:
   button_text: "Register now!"
 
   funfacts:
-  - name : "30 Speakers"
+  - name : "40 Speakers"
     icon : "fa-microphone"
 
   - name : "500+ Seats"

--- a/hugo.toml
+++ b/hugo.toml
@@ -121,11 +121,11 @@ hasChildren = true
   url = "about/"
   weight = 1
 
-  #[[menu.main]]
-  #parent = "About TXLF"
-  #name = "Speakers"
-  #url = "speakers/"
-  #weight = 2
+  [[menu.main]]
+  parent = "About TXLF"
+  name = "Speakers"
+  url = "https://pretalx.com/txlf2026/speaker/"
+  weight = 2
 
   [[menu.main]]
   parent = "About TXLF"
@@ -153,7 +153,7 @@ hasChildren = true
 
 [[menu.main]]
 name = "Schedule"
-url = "schedule/"
+url = "https://pretalx.com/txlf2026/schedule/"
 weight = 4
 
 [[menu.main]]

--- a/themes/eventre-hugo/layouts/index.html
+++ b/themes/eventre-hugo/layouts/index.html
@@ -157,7 +157,11 @@
             </div>
           </div>
           <div class="content text-center">
+            {{ if .Params.link }}
+            <h5><a href="{{ .Params.link }}">{{.Title }}</a></h5>
+            {{ else }}
             <h5><a href="{{ .Permalink }}">{{.Title }}</a></h5>
+            {{ end }}
             <p>{{ .Params.Designation | markdownify }}</p>
           </div>
         </div>


### PR DESCRIPTION
This will remove the need to manage talks in `data/homepage.yml`.  Schedule links go out to the Pretalx website, and everything is managed there.